### PR TITLE
Add Tavern gRPC tests

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,3 @@
+import pykwalify.core as _pkc
+if not hasattr(_pkc, 'yaml') and hasattr(_pkc, 'yml'):
+    _pkc.yaml = _pkc.yml

--- a/tests/calculator.tavern.yaml
+++ b/tests/calculator.tavern.yaml
@@ -1,0 +1,64 @@
+---
+test_name: Calculator operations
+
+config:
+  backends:
+    grpc: grpc
+  grpc:
+    connect:
+      host: localhost
+      port: 50051
+    proto:
+      source: proto
+      module: proto
+
+stages:
+  - name: add two numbers
+    grpc_request:
+      service: calculator.Calculator/Add
+      json:
+        a: 10
+        b: 5
+    grpc_response:
+      body:
+        result: 15
+
+  - name: subtract two numbers
+    grpc_request:
+      service: calculator.Calculator/Subtract
+      json:
+        a: 10
+        b: 5
+    grpc_response:
+      body:
+        result: 5
+
+  - name: multiply two numbers
+    grpc_request:
+      service: calculator.Calculator/Multiply
+      json:
+        a: 6
+        b: 7
+    grpc_response:
+      body:
+        result: 42
+
+  - name: divide two numbers
+    grpc_request:
+      service: calculator.Calculator/Divide
+      json:
+        a: 20
+        b: 5
+    grpc_response:
+      body:
+        result: 4
+
+  - name: division by zero returns error
+    grpc_request:
+      service: calculator.Calculator/Divide
+      json:
+        a: 5
+        b: 0
+    grpc_response:
+      status: INVALID_ARGUMENT
+      details: division by zero


### PR DESCRIPTION
## Summary
- add Tavern-based gRPC tests for calculator service
- add site customizations for pykwalify compatibility

## Testing
- `PYTHONPATH=. pytest -vv tests/calculator.tavern.yaml` *(fails: BadSchemaError)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e7313e6c832089ae785a57f49dbf