### PR TITLE
Add ghz normal and error tests with latency measurement

### DIFF
--- a/.github/workflows/ghz-test.yml
+++ b/.github/workflows/ghz-test.yml
@@ -14,11 +14,14 @@ jobs:
           go-version: '1.x'
       - name: Install ghz
         run: go install github.com/bojand/ghz/cmd/ghz@latest
-      - name: Run ghz test
+      - name: Run ghz tests
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin
           go run main.go &
           SERVER_PID=$!
           sleep 2
-          ghz --config tests/ghz_add.json
+          echo "Add latency (ms):"
+          ghz --config tests/ghz_add.json --format json | jq '.details[0].latency / 1000000'
+          echo "Divide by zero error test:"
+          ghz --config tests/ghz_divide_error.json --format json | jq '.statusCodeDistribution, .errorDistribution'
           kill $SERVER_PID

--- a/README.md
+++ b/README.md
@@ -42,14 +42,17 @@ go run main.go
 
 ## テスト
 
-[gRPC ベンチマークツール ghz](https://github.com/bojand/ghz) を利用した設定ファイル `tests/ghz_add.json` が用意されています。サーバーを起動した状態で次を実行すると `Add` メソッドが 1 回呼び出されます。
+[gRPC ベンチマークツール ghz](https://github.com/bojand/ghz) を利用した設定ファイルが用意されています。サーバーを起動した状態で次を実行すると `Add` メソッドの正常系と `Divide` メソッドの異常系をテストできます。`Add` のテストではリクエストからレスポンスまでの時間 (ms) を計測します。
 
 ```bash
 # 1つ目のターミナル
 go run main.go
 
-# 2つ目のターミナル
-ghz --config tests/ghz_add.json
+# 2つ目のターミナル: 正常系
+ghz --config tests/ghz_add.json --format json | jq '.details[0].latency / 1000000'
+
+# 2つ目のターミナル: 異常系
+ghz --config tests/ghz_divide_error.json
 ```
 
-GitHub Actions でも同じテストが自動で実行されます。
+GitHub Actions でもこれらのテストが自動で実行されます。

--- a/tests/ghz_divide_error.json
+++ b/tests/ghz_divide_error.json
@@ -1,0 +1,9 @@
+{
+  "proto": "proto/calculator.proto",
+  "call": "calculator.Calculator.Divide",
+  "insecure": true,
+  "total": 1,
+  "data": { "a": 7, "b": 0 },
+  "host": "localhost:50051",
+  "timeout": "5s"
+}


### PR DESCRIPTION
## Summary
- add ghz test config for divide by zero error
- run ghz add test with latency measurement and divide error test in CI
- document running both ghz tests

## Testing
- `ghz --config tests/ghz_add.json --format json | jq '.details[0].latency / 1000000'`
- `ghz --config tests/ghz_divide_error.json --format json | jq '.statusCodeDistribution, .errorDistribution'`


------
https://chatgpt.com/codex/tasks/task_e_68a8f8c4a1fc83209cfc095460e415c8